### PR TITLE
Fix broken FQDNs

### DIFF
--- a/roles/httpd-classic/templates/index.html.j2
+++ b/roles/httpd-classic/templates/index.html.j2
@@ -153,13 +153,11 @@
 
 			<h2>Manage Your Password</h2>
 			<ul>
-
-				<li><a href="https://{{ ansible_fqdn }}/sspr/">Change Password, Update Profile, and more</a>
+				<li><a href="https://{{ ansible_nodename }}/sspr/">Change Password, Update Profile, and more</a>
 				</li>
-				<li><a href="https://{{ ansible_fqdn }}/sspr/public/forgottenpassword">Forgotten Password</a>
+				<li><a href="https://{{ ansible_nodename }}/sspr/public/forgottenpassword">Forgotten Password</a>
 				</li>
-				<li><a href="https://{{ ansible_fqdn }}/sspr/public/forgottenusername">Forgotten Username</a>
-
+				<li><a href="https://{{ ansible_nodename }}/sspr/public/forgottenusername">Forgotten Username</a>
 				</li>
 			</ul>
 

--- a/roles/httpd-classic/templates/redirect.conf.j2
+++ b/roles/httpd-classic/templates/redirect.conf.j2
@@ -1,3 +1,3 @@
 # {{ ansible_managed }}
 
-# RedirectMatch ^/$ https://{{ ansible_fqdn }}/sspr
+# RedirectMatch ^/$ https://{{ ansible_nodename }}/sspr

--- a/roles/shibd-classic/templates/shibboleth2.xml.j2
+++ b/roles/shibd-classic/templates/shibboleth2.xml.j2
@@ -12,7 +12,7 @@
     -->
 
     <!-- The ApplicationDefaults element is where most of Shibboleth's SAML bits are defined. -->
-    <ApplicationDefaults entityID="https://{{ ansible_fqdn }}/shibboleth"
+    <ApplicationDefaults entityID="{{ sp_entity_id }}"
         REMOTE_USER="eppn"
         cipherSuites="DEFAULT:!EXP:!LOW:!aNULL:!eNULL:!DES:!IDEA:!SEED:!RC4:!3DES:!kRSA:!SSLv2:!SSLv3:!TLSv1:!TLSv1.1">
 


### PR DESCRIPTION
Recent changes for password-uat.its were wrong and broke the Ansible playbooks for password-dev.its.  The underlying problem is that ansible_fqdn was basing the value on /etc/hosts and returning something other than an actual FQDN.